### PR TITLE
added outputs to make CDP simpler when copy values across

### DIFF
--- a/cloudformation/setup.json
+++ b/cloudformation/setup.json
@@ -615,5 +615,44 @@
       },
       "DependsOn" : "LogRole"
     }
+  },
+  "Outputs": {
+    "LogInstanceProfile": {
+      "Description": "Log Instance Profile Name",
+      "Value": { "Ref" : "LogAccessInstanceProfile" }
+    },
+    "LogsLocationBase": {
+      "Description": "S3 path for log directory",
+      "Value": { "Fn::Join": [ "/", [ { "Ref" : "S3BucketName" }, "logs/" ] ] }
+    },
+    "RangerAuditRole": {
+      "Description": "Ranger Audit Role Name",
+      "Value": { "Ref" : "RangerAuditRole" }
+    },
+    "DataInstanceProfile": {
+      "Description": "Data Access Instance Profile Name",
+      "Value": { "Ref" : "DataAccessInstanceProfile" }
+    },
+    "StorageLocationBase": {
+      "Description": "S3 path for data directory",
+      "Value": { "Ref" : "S3BucketName" }
+    },
+    "DataAccessRole": {
+      "Description": "Data Access Role Name",
+      "Value": { "Ref" : "DatalakeAdminRole" }
+    },
+    "DyanmoDbTableName": {
+      "Description": "Data Access Role Name",
+      "Value": {
+        "Fn::Join" : [
+          "", [
+            {
+              "Ref" : "prefix"
+            },
+            "-dynamodb-table"
+            ]
+          ]
+        }
+    }
   }
 }


### PR DESCRIPTION
When deploying CDP it can be confusing to complete the deployment UI with the values that match explicit restrictions in the IAM policy resource paths. This outputs the required values to make the deployment simpler after running this quickstart.